### PR TITLE
Explicitely use bash

### DIFF
--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -13,9 +13,9 @@ RUN wget -O /tmp/terraform.zip "https://releases.hashicorp.com/terraform/${terra
     chmod +x /usr/local/bin/terraform && \
     rm /tmp/terraform.zip
 
-RUN sh -c "$(curl -fsSL https://raw.github.com/orange-cloudfoundry/terraform-provider-cloudfoundry/master/bin/install.sh)"
+RUN bash -c "$(curl -fsSL https://raw.github.com/orange-cloudfoundry/terraform-provider-cloudfoundry/master/bin/install.sh)"
 
-RUN sh -c "$(curl -fsSL https://raw.github.com/orange-cloudfoundry/terraform-provider-credhub/master/bin/install.sh)"
+RUN bash -c "$(curl -fsSL https://raw.github.com/orange-cloudfoundry/terraform-provider-credhub/master/bin/install.sh)"
 
 RUN curl -SsL https://github.com/kvz/json2hcl/releases/download/${JSON2HCL_VERSION}/json2hcl_${JSON2HCL_VERSION}_linux_amd64 \
 	| tee /usr/local/bin/json2hcl > /dev/null && chmod +x /usr/local/bin/json2hcl


### PR DESCRIPTION
terraform-provider-cloudfoundry/master/bin/install.sh uses bash specific syntax so we have to call it with bash (rather than sh that can be dash under ubuntu)