### PR TITLE
Fix buildpack image

### DIFF
--- a/buildpack/Dockerfile
+++ b/buildpack/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.3-slim-stretch
 
-ENV PACKAGES "bash curl openssh-client file git openssl ca-certificates wget libffi-dev zip gcc ruby-dev"
+ENV PACKAGES "bash curl openssh-client file git openssl ca-certificates wget libffi-dev zip gcc ruby-dev make"
 
 RUN gem install bundler -v 2.0.1
 


### PR DESCRIPTION
Thie PR adds missing `make` package required for building java buildpack