### PR TITLE
update dependencies

### DIFF
--- a/base-debian/Dockerfile
+++ b/base-debian/Dockerfile
@@ -6,6 +6,10 @@ RUN apt-get update -y && \
   apt-get install -y $PACKAGES
 
 RUN bash -c "$(curl -fsSL https://raw.github.com/ArthurHlt/notifslack/master/bin/install.sh)"
+RUN curl -fL https://getcli.jfrog.io | sh && mv jfrog /usr/local/bin/
+RUN curl -fL https://github.com/cloudfoundry/bosh-cli/releases/download/v5.4.0/bosh-cli-5.4.0-linux-amd64 | install /dev/stdin /usr/local/bin/bosh
+
+RUN bash -c "$(curl -fsSL https://raw.github.com/ArthurHlt/notifslack/master/bin/install.sh)"
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \

--- a/buildpack/Dockerfile
+++ b/buildpack/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y $PACKAGES && rm -rf /var/lib/apt/lists/
 
 RUN curl -L 'https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64' -o /usr/local/bin/jq && chmod +x /usr/local/bin/jq
 
-RUN curl -L 'https://storage.googleapis.com/golang/go1.11.2.linux-amd64.tar.gz' -o go.tar.gz && tar -C /usr/local -xzf go.tar.gz && rm -f go.tar.gz
+RUN curl -L 'https://dl.google.com/go/go1.12.2.linux-amd64.tar.gz' -o go.tar.gz && tar -C /usr/local -xzf go.tar.gz && rm -f go.tar.gz
 
 RUN mkdir -p /gopath/bin
 ENV GOPATH /gopath


### PR DESCRIPTION
### buildpack image
- bump go version to 1.12.2

### base -image
- add bosh-cli v5.4.0
- add jfrog-cli