### PR TITLE
Bump ruby and bundler version

### DIFF
--- a/buildpack/Dockerfile
+++ b/buildpack/Dockerfile
@@ -1,10 +1,10 @@
-FROM ruby:2.3-slim-stretch
+FROM ruby:2.5-slim-stretch
 
 ARG BOSH_CLI_VERSION="5.5.1"
 
 ENV PACKAGES "bash curl openssh-client file git openssl ca-certificates wget libffi-dev zip gcc ruby-dev make"
 
-RUN gem install bundler -v 2.0.1
+RUN gem install bundler -v 2.1.4
 
 RUN apt-get update && apt-get install -y $PACKAGES && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Starting with [Java Buildpack 4.30](https://github.com/cloudfoundry/java-buildpack/releases/tag/v4.30), ruby 2.3 and 2.4 are not supported anymore.

Error during build without this change:
```
Warning: the running version of Bundler (2.0.1) is older than the version that created the lockfile (2.1.4). We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
Fetching gem metadata from https://rubygems.org/.........
rubocop-0.82.0 requires ruby version >= 2.4.0, which is incompatible with the current version, ruby 2.3.8p459
```